### PR TITLE
Break security bean cycle

### DIFF
--- a/src/main/java/com/example/bankcards/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/bankcards/security/JwtAuthenticationFilter.java
@@ -8,8 +8,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.stereotype.Component;
+import com.example.bankcards.security.AppUserDetailsService;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -18,13 +17,12 @@ import java.io.IOException;
 /**
  * Фильтр сервлета, который аутентифицирует пользователей по JWT токену из запроса.
  */
-@Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider tokenProvider;
-    private final UserDetailsService userDetailsService;
+    private final AppUserDetailsService userDetailsService;
 
-    public JwtAuthenticationFilter(JwtTokenProvider tokenProvider, UserDetailsService userDetailsService) {
+    public JwtAuthenticationFilter(JwtTokenProvider tokenProvider, AppUserDetailsService userDetailsService) {
         this.tokenProvider = tokenProvider;
         this.userDetailsService = userDetailsService;
     }

--- a/src/main/java/com/example/bankcards/security/SecurityConfig.java
+++ b/src/main/java/com/example/bankcards/security/SecurityConfig.java
@@ -19,14 +19,11 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableMethodSecurity
 public class SecurityConfig {
 
-    private final JwtAuthenticationFilter jwtFilter;
-
-    public SecurityConfig(JwtAuthenticationFilter jwtFilter) {
-        this.jwtFilter = jwtFilter;
-    }
-
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http,
+                                           AppUserDetailsService uds,
+                                           JwtTokenProvider tokenProvider) throws Exception {
+        JwtAuthenticationFilter jwtFilter = new JwtAuthenticationFilter(tokenProvider, uds);
         http
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))


### PR DESCRIPTION
## Summary
- decouple JwtAuthenticationFilter from SecurityConfig
- construct authentication filter in `filterChain`
- narrow JwtAuthenticationFilter constructor to `AppUserDetailsService`

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685405f59fd08327897805c4b692efcf