### PR TITLE
Implement card and user management

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -32,3 +32,101 @@ paths:
       responses:
         "200":
           description: Карта создана
+  /api/cards/my:
+    get:
+      summary: Список карт пользователя
+      parameters:
+        - in: query
+          name: page
+          schema:
+            type: integer
+        - in: query
+          name: size
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Список карт пользователя
+  /api/cards/{id}/balance:
+    get:
+      summary: Баланс карты
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Баланс
+  /api/cards/{id}/deposit:
+    post:
+      summary: Пополнение карты
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Баланс обновлен
+  /api/cards/{id}/withdraw:
+    post:
+      summary: Снятие с карты
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Баланс обновлен
+  /api/cards/{id}/block:
+    post:
+      summary: Блокировка карты
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Карта заблокирована
+  /api/cards/transfer:
+    post:
+      summary: Перевод между картами пользователя
+      responses:
+        "200":
+          description: Перевод выполнен
+  /api/users:
+    post:
+      summary: Создать пользователя
+      responses:
+        "200":
+          description: Пользователь создан
+  /api/users/{id}:
+    put:
+      summary: Обновить пользователя
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Пользователь обновлен
+    delete:
+      summary: Удалить пользователя
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        "204":
+          description: Пользователь удален

--- a/src/main/java/com/example/bankcards/controller/AuthController.java
+++ b/src/main/java/com/example/bankcards/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.example.bankcards.controller;
 
+import com.example.bankcards.dto.UserDto;
 import com.example.bankcards.entity.Role;
 import com.example.bankcards.entity.User;
 import com.example.bankcards.security.JwtTokenProvider;
@@ -9,6 +10,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Collections;
@@ -42,11 +44,10 @@ public class AuthController {
     }
 
     @PostMapping("/register")
-    public ResponseEntity<?> register(@RequestParam String username,
-                                      @RequestParam String password) {
+    public ResponseEntity<?> register(@Valid @RequestBody UserDto dto) {
         User user = new User();
-        user.setUsername(username);
-        user.setPassword(password);
+        user.setUsername(dto.getUsername());
+        user.setPassword(dto.getPassword());
         user.setRoles(Collections.singleton(Role.ROLE_USER));
         userService.save(user);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/example/bankcards/controller/CardController.java
+++ b/src/main/java/com/example/bankcards/controller/CardController.java
@@ -1,13 +1,17 @@
 package com.example.bankcards.controller;
 
+import com.example.bankcards.dto.AmountDto;
 import com.example.bankcards.dto.CardDto;
+import com.example.bankcards.dto.TransferDto;
+import com.example.bankcards.entity.Card;
+import com.example.bankcards.exception.ResourceNotFoundException;
 import com.example.bankcards.service.CardService;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import com.example.bankcards.service.UserService;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Контроллер для работы с API, связанным с картами.
@@ -16,15 +20,70 @@ import java.util.stream.Collectors;
 @RequestMapping("/api/cards")
 public class CardController {
     private final CardService cardService;
+    private final UserService userService;
 
-    public CardController(CardService cardService) {
+    public CardController(CardService cardService, UserService userService) {
         this.cardService = cardService;
+        this.userService = userService;
     }
 
-    @GetMapping
-    public List<CardDto> list() {
-        return cardService.findAll().stream()
-                .map(CardDto::fromEntity)
-                .collect(Collectors.toList());
+    @GetMapping("/my")
+    public Page<CardDto> myCards(@RequestParam(defaultValue = "0") int page,
+                                 @RequestParam(defaultValue = "10") int size) {
+        String username = userService.getCurrentUser().orElseThrow(() -> new ResourceNotFoundException("User not found")).getUsername();
+        return cardService.findByOwner(username, PageRequest.of(page, size))
+                .map(CardDto::fromEntity);
+    }
+
+    @GetMapping("/{id}")
+    public CardDto get(@PathVariable Long id) {
+        String username = userService.getCurrentUser().orElseThrow(() -> new ResourceNotFoundException("User not found")).getUsername();
+        Card card = cardService.findByIdAndOwner(id, username)
+                .orElseThrow(() -> new ResourceNotFoundException("Card not found"));
+        return CardDto.fromEntity(card);
+    }
+
+    @PostMapping("/transfer")
+    public void transfer(@Valid @RequestBody TransferDto dto) {
+        String username = userService.getCurrentUser().orElseThrow(() -> new ResourceNotFoundException("User not found")).getUsername();
+        Card from = cardService.findByIdAndOwner(dto.getFromId(), username)
+                .orElseThrow(() -> new ResourceNotFoundException("Card not found"));
+        Card to = cardService.findByIdAndOwner(dto.getToId(), username)
+                .orElseThrow(() -> new ResourceNotFoundException("Card not found"));
+        cardService.transfer(from, to, dto.getAmount());
+    }
+
+    @PostMapping("/{id}/block")
+    public CardDto block(@PathVariable Long id) {
+        String username = userService.getCurrentUser().orElseThrow(() -> new ResourceNotFoundException("User not found")).getUsername();
+        Card card = cardService.findByIdAndOwner(id, username)
+                .orElseThrow(() -> new ResourceNotFoundException("Card not found"));
+        return CardDto.fromEntity(cardService.blockCard(card));
+    }
+
+    @GetMapping("/{id}/balance")
+    public AmountDto balance(@PathVariable Long id) {
+        String username = userService.getCurrentUser().orElseThrow(() -> new ResourceNotFoundException("User not found")).getUsername();
+        Card card = cardService.findByIdAndOwner(id, username)
+                .orElseThrow(() -> new ResourceNotFoundException("Card not found"));
+        AmountDto dto = new AmountDto();
+        dto.setAmount(card.getBalance());
+        return dto;
+    }
+
+    @PostMapping("/{id}/deposit")
+    public CardDto deposit(@PathVariable Long id, @Valid @RequestBody AmountDto dto) {
+        String username = userService.getCurrentUser().orElseThrow(() -> new ResourceNotFoundException("User not found")).getUsername();
+        Card card = cardService.findByIdAndOwner(id, username)
+                .orElseThrow(() -> new ResourceNotFoundException("Card not found"));
+        return CardDto.fromEntity(cardService.deposit(card, dto.getAmount()));
+    }
+
+    @PostMapping("/{id}/withdraw")
+    public CardDto withdraw(@PathVariable Long id, @Valid @RequestBody AmountDto dto) {
+        String username = userService.getCurrentUser().orElseThrow(() -> new ResourceNotFoundException("User not found")).getUsername();
+        Card card = cardService.findByIdAndOwner(id, username)
+                .orElseThrow(() -> new ResourceNotFoundException("Card not found"));
+        return CardDto.fromEntity(cardService.withdraw(card, dto.getAmount()));
     }
 }

--- a/src/main/java/com/example/bankcards/controller/UserController.java
+++ b/src/main/java/com/example/bankcards/controller/UserController.java
@@ -1,0 +1,50 @@
+package com.example.bankcards.controller;
+
+import com.example.bankcards.dto.UserDto;
+import com.example.bankcards.entity.Role;
+import com.example.bankcards.entity.User;
+import com.example.bankcards.exception.ResourceNotFoundException;
+import com.example.bankcards.service.UserService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Collections;
+
+/**
+ * Controller for user management (update/delete).
+ */
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping
+    public ResponseEntity<?> create(@Valid @RequestBody UserDto dto) {
+        User user = new User();
+        user.setUsername(dto.getUsername());
+        user.setPassword(dto.getPassword());
+        user.setRoles(Collections.singleton(Role.ROLE_USER));
+        userService.save(user);
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<?> update(@PathVariable Long id, @Valid @RequestBody UserDto dto) {
+        User user = userService.findById(id).orElseThrow(() -> new ResourceNotFoundException("User not found"));
+        user.setUsername(dto.getUsername());
+        user.setPassword(dto.getPassword());
+        userService.update(user);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> delete(@PathVariable Long id) {
+        userService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/example/bankcards/dto/AmountDto.java
+++ b/src/main/java/com/example/bankcards/dto/AmountDto.java
@@ -1,0 +1,22 @@
+package com.example.bankcards.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+
+/**
+ * DTO for amount operations like deposit/withdraw.
+ */
+public class AmountDto {
+    @NotNull
+    @Min(1)
+    private BigDecimal amount;
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+}

--- a/src/main/java/com/example/bankcards/dto/TransferDto.java
+++ b/src/main/java/com/example/bankcards/dto/TransferDto.java
@@ -1,0 +1,42 @@
+package com.example.bankcards.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+
+/**
+ * DTO for card to card transfers.
+ */
+public class TransferDto {
+    @NotNull
+    private Long fromId;
+    @NotNull
+    private Long toId;
+    @NotNull
+    @Min(1)
+    private BigDecimal amount;
+
+    public Long getFromId() {
+        return fromId;
+    }
+
+    public void setFromId(Long fromId) {
+        this.fromId = fromId;
+    }
+
+    public Long getToId() {
+        return toId;
+    }
+
+    public void setToId(Long toId) {
+        this.toId = toId;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+}

--- a/src/main/java/com/example/bankcards/dto/UserDto.java
+++ b/src/main/java/com/example/bankcards/dto/UserDto.java
@@ -1,0 +1,38 @@
+package com.example.bankcards.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * DTO for user registration and update.
+ */
+public class UserDto {
+    private Long id;
+    @NotBlank
+    private String username;
+    @NotBlank
+    private String password;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/main/java/com/example/bankcards/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/bankcards/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.example.bankcards.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -23,5 +24,14 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiError> handleGeneric(Exception ex) {
         ApiError error = new ApiError(LocalDateTime.now(), "Internal server error");
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiError> handleValidation(MethodArgumentNotValidException ex) {
+        String message = ex.getBindingResult().getFieldErrors().stream()
+                .map(e -> e.getField() + " " + e.getDefaultMessage())
+                .findFirst().orElse("Validation error");
+        ApiError error = new ApiError(LocalDateTime.now(), message);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(error);
     }
 }

--- a/src/main/java/com/example/bankcards/repository/CardRepository.java
+++ b/src/main/java/com/example/bankcards/repository/CardRepository.java
@@ -1,11 +1,20 @@
 package com.example.bankcards.repository;
 
 import com.example.bankcards.entity.Card;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
 
 /**
  * Репозиторий для выполнения CRUD-операций над сущностями {@link Card}.
  */
 
 public interface CardRepository extends JpaRepository<Card, Long> {
+    Page<Card> findByOwnerUsername(String username, Pageable pageable);
+
+    Optional<Card> findByIdAndOwnerUsername(Long id, String username);
+
+    Optional<Card> findByNumberAndOwnerUsername(String number, String username);
 }

--- a/src/main/java/com/example/bankcards/service/CardService.java
+++ b/src/main/java/com/example/bankcards/service/CardService.java
@@ -1,10 +1,16 @@
 package com.example.bankcards.service;
 
 import com.example.bankcards.entity.Card;
+import com.example.bankcards.entity.CardStatus;
 import com.example.bankcards.repository.CardRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
+
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Сервис для работы с карточками в базе данных.
@@ -23,5 +29,39 @@ public class CardService {
 
     public List<Card> findAll() {
         return cardRepository.findAll();
+    }
+
+    public Page<Card> findByOwner(String username, Pageable pageable) {
+        return cardRepository.findByOwnerUsername(username, pageable);
+    }
+
+    public Optional<Card> findByIdAndOwner(Long id, String username) {
+        return cardRepository.findByIdAndOwnerUsername(id, username);
+    }
+
+    public Optional<Card> findByNumberAndOwner(String number, String username) {
+        return cardRepository.findByNumberAndOwnerUsername(number, username);
+    }
+
+    public Card blockCard(Card card) {
+        card.setStatus(CardStatus.BLOCKED);
+        return cardRepository.save(card);
+    }
+
+    public Card deposit(Card card, BigDecimal amount) {
+        card.setBalance(card.getBalance().add(amount));
+        return cardRepository.save(card);
+    }
+
+    public Card withdraw(Card card, BigDecimal amount) {
+        card.setBalance(card.getBalance().subtract(amount));
+        return cardRepository.save(card);
+    }
+
+    public void transfer(Card from, Card to, BigDecimal amount) {
+        from.setBalance(from.getBalance().subtract(amount));
+        to.setBalance(to.getBalance().add(amount));
+        cardRepository.save(from);
+        cardRepository.save(to);
     }
 }

--- a/src/main/java/com/example/bankcards/service/UserService.java
+++ b/src/main/java/com/example/bankcards/service/UserService.java
@@ -2,6 +2,7 @@ package com.example.bankcards.service;
 
 import com.example.bankcards.entity.User;
 import com.example.bankcards.repository.UserRepository;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -25,7 +26,28 @@ public class UserService {
         return userRepository.save(user);
     }
 
+    public User update(User user) {
+        return save(user);
+    }
+
+    public void delete(Long id) {
+        userRepository.deleteById(id);
+    }
+
+    public Optional<User> findById(Long id) {
+        return userRepository.findById(id);
+    }
+
     public Optional<User> findByUsername(String username) {
         return userRepository.findByUsername(username);
+    }
+
+    public Optional<User> getCurrentUser() {
+        String username = SecurityContextHolder.getContext().getAuthentication() == null ? null :
+                SecurityContextHolder.getContext().getAuthentication().getName();
+        if (username == null) {
+            return Optional.empty();
+        }
+        return findByUsername(username);
     }
 }


### PR DESCRIPTION
## Summary
- add user CRUD controller and DTOs
- add card management operations like transfers, balance, block, deposit, withdraw
- extend repository and services for new features
- update exception handler for validation
- document API endpoints in OpenAPI

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68542512f18c8327ac69a55451aa8709