### PR TITLE
Add register docs and Russian javadocs

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -21,6 +21,23 @@ paths:
       responses:
         "200":
           description: JWT токен
+  /api/auth/register:
+    post:
+      summary: Регистрация пользователя
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                username:
+                  type: string
+                password:
+                  type: string
+      responses:
+        "200":
+          description: Пользователь зарегистрирован
   /api/cards:
     get:
       summary: Получить все карты

--- a/src/main/java/com/example/bankcards/config/CorsConfig.java
+++ b/src/main/java/com/example/bankcards/config/CorsConfig.java
@@ -5,6 +5,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+/**
+ * Конфигурация CORS, разрешающая запросы из любых источников.
+ */
 @Configuration
 public class CorsConfig {
 

--- a/src/main/java/com/example/bankcards/config/OpenApiConfig.java
+++ b/src/main/java/com/example/bankcards/config/OpenApiConfig.java
@@ -5,6 +5,9 @@ import io.swagger.v3.oas.models.info.Info;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * Конфигурация OpenAPI для Swagger UI.
+ */
 @Configuration
 public class OpenApiConfig {
 

--- a/src/main/java/com/example/bankcards/controller/UserController.java
+++ b/src/main/java/com/example/bankcards/controller/UserController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.Collections;
 
 /**
- * Controller for user management (update/delete).
+ * Контроллер управления пользователями (обновление/удаление).
  */
 @RestController
 @RequestMapping("/api/users")

--- a/src/main/java/com/example/bankcards/dto/AmountDto.java
+++ b/src/main/java/com/example/bankcards/dto/AmountDto.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 
 /**
- * DTO for amount operations like deposit/withdraw.
+ * DTO для операций с суммой (пополнение/снятие).
  */
 public class AmountDto {
     @NotNull

--- a/src/main/java/com/example/bankcards/dto/CreateCardDto.java
+++ b/src/main/java/com/example/bankcards/dto/CreateCardDto.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 
 /**
- * DTO for creating cards by admin.
+ * DTO для создания карты администратором.
  */
 public class CreateCardDto {
     @NotBlank

--- a/src/main/java/com/example/bankcards/dto/TransferDto.java
+++ b/src/main/java/com/example/bankcards/dto/TransferDto.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 
 /**
- * DTO for card to card transfers.
+ * DTO для переводов между картами.
  */
 public class TransferDto {
     @NotNull

--- a/src/main/java/com/example/bankcards/dto/UserDto.java
+++ b/src/main/java/com/example/bankcards/dto/UserDto.java
@@ -3,7 +3,7 @@ package com.example.bankcards.dto;
 import jakarta.validation.constraints.NotBlank;
 
 /**
- * DTO for user registration and update.
+ * DTO регистрации и обновления пользователя.
  */
 public class UserDto {
     private Long id;

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -21,6 +21,23 @@ paths:
       responses:
         "200":
           description: JWT токен
+  /api/auth/register:
+    post:
+      summary: Регистрация пользователя
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                username:
+                  type: string
+                password:
+                  type: string
+      responses:
+        "200":
+          description: Пользователь зарегистрирован
   /api/cards:
     get:
       summary: Получить все карты


### PR DESCRIPTION
## Summary
- document user registration endpoint in OpenAPI
- translate DTO and controller javadocs to Russian
- add missing javadocs for configuration classes

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854623710c08327bc3dd93f5effdf40