### PR TITLE
Add card number encryption and masking

### DIFF
--- a/src/main/java/com/example/bankcards/converter/CardNumberEncryptConverter.java
+++ b/src/main/java/com/example/bankcards/converter/CardNumberEncryptConverter.java
@@ -1,0 +1,49 @@
+package com.example.bankcards.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+/**
+ * JPA converter that encrypts and decrypts card numbers using AES.
+ */
+@Converter
+public class CardNumberEncryptConverter implements AttributeConverter<String, String> {
+
+    private static final String ALGO = "AES";
+    private static final byte[] KEY = "MySecretKey12345".getBytes(StandardCharsets.UTF_8);
+
+    @Override
+    public String convertToDatabaseColumn(String attribute) {
+        if (attribute == null) {
+            return null;
+        }
+        try {
+            Cipher cipher = Cipher.getInstance(ALGO);
+            cipher.init(Cipher.ENCRYPT_MODE, new SecretKeySpec(KEY, ALGO));
+            byte[] encrypted = cipher.doFinal(attribute.getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(encrypted);
+        } catch (Exception e) {
+            throw new IllegalStateException("Encryption error", e);
+        }
+    }
+
+    @Override
+    public String convertToEntityAttribute(String dbData) {
+        if (dbData == null) {
+            return null;
+        }
+        try {
+            Cipher cipher = Cipher.getInstance(ALGO);
+            cipher.init(Cipher.DECRYPT_MODE, new SecretKeySpec(KEY, ALGO));
+            byte[] decoded = Base64.getDecoder().decode(dbData);
+            return new String(cipher.doFinal(decoded), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new IllegalStateException("Decryption error", e);
+        }
+    }
+}

--- a/src/main/java/com/example/bankcards/dto/CardDto.java
+++ b/src/main/java/com/example/bankcards/dto/CardDto.java
@@ -1,6 +1,7 @@
 package com.example.bankcards.dto;
 
 import com.example.bankcards.entity.Card;
+import com.example.bankcards.util.CardMaskUtil;
 
 import java.math.BigDecimal;
 
@@ -17,7 +18,7 @@ public class CardDto {
     public static CardDto fromEntity(Card card) {
         CardDto dto = new CardDto();
         dto.setId(card.getId());
-        dto.setNumber(card.getNumber());
+        dto.setNumber(CardMaskUtil.mask(card.getNumber()));
         dto.setExpiry(card.getExpiry());
         dto.setStatus(card.getStatus().name());
         dto.setBalance(card.getBalance());

--- a/src/main/java/com/example/bankcards/entity/Card.java
+++ b/src/main/java/com/example/bankcards/entity/Card.java
@@ -1,6 +1,7 @@
 package com.example.bankcards.entity;
 
 import jakarta.persistence.*;
+import com.example.bankcards.converter.CardNumberEncryptConverter;
 import java.util.Objects;
 
 import java.math.BigDecimal;
@@ -19,6 +20,7 @@ public class Card {
     private Long version;
 
     @Column(nullable = false, unique = true)
+    @Convert(converter = CardNumberEncryptConverter.class)
     private String number;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/resources/db/migration/db.changelog-master.yaml
+++ b/src/main/resources/db/migration/db.changelog-master.yaml
@@ -79,3 +79,11 @@ databaseChangeLog:
             referencedTableName: users
             referencedColumnNames: id
             constraintName: fk_user_roles_users
+
+  - changeSet:
+      id: 2
+      author: encrypt
+      changes:
+        - sql: CREATE EXTENSION IF NOT EXISTS pgcrypto;
+        - sql: |
+            UPDATE cards SET number = encode(pgp_sym_encrypt(number, 'MySecretKey12345'), 'base64');

--- a/src/test/java/com/example/bankcards/converter/CardNumberEncryptConverterTest.java
+++ b/src/test/java/com/example/bankcards/converter/CardNumberEncryptConverterTest.java
@@ -1,0 +1,18 @@
+package com.example.bankcards.converter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CardNumberEncryptConverterTest {
+
+    @Test
+    void encryptsAndDecrypts() {
+        CardNumberEncryptConverter conv = new CardNumberEncryptConverter();
+        String num = "1234567890123456";
+        String enc = conv.convertToDatabaseColumn(num);
+        assertNotEquals(num, enc);
+        String dec = conv.convertToEntityAttribute(enc);
+        assertEquals(num, dec);
+    }
+}

--- a/src/test/java/com/example/bankcards/dto/CardDtoTest.java
+++ b/src/test/java/com/example/bankcards/dto/CardDtoTest.java
@@ -1,0 +1,24 @@
+package com.example.bankcards.dto;
+
+import com.example.bankcards.entity.Card;
+import com.example.bankcards.entity.CardStatus;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CardDtoTest {
+    @Test
+    void fromEntityMasksNumber() {
+        Card card = new Card();
+        card.setId(1L);
+        card.setNumber("1234567812345678");
+        card.setExpiry("12/34");
+        card.setStatus(CardStatus.ACTIVE);
+        card.setBalance(BigDecimal.TEN);
+
+        CardDto dto = CardDto.fromEntity(card);
+        assertEquals("**** **** **** 5678", dto.getNumber());
+    }
+}


### PR DESCRIPTION
## Summary
- encrypt the card number field using a JPA converter
- mask card number in `CardDto.fromEntity`
- migrate existing data to encrypted form
- add unit tests for encryption converter and dto masking

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68551c6ea4048327b807574954e00fd5