### PR TITLE
Add card search by number

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -61,6 +61,11 @@ paths:
           name: size
           schema:
             type: integer
+        - in: query
+          name: search
+          schema:
+            type: string
+          description: Поиск по номеру карты
       responses:
         "200":
           description: Список карт пользователя

--- a/src/main/java/com/example/bankcards/controller/CardController.java
+++ b/src/main/java/com/example/bankcards/controller/CardController.java
@@ -55,9 +55,11 @@ public class CardController {
 
     @GetMapping("/my")
     public Page<CardDto> myCards(@RequestParam(defaultValue = "0") int page,
-                                 @RequestParam(defaultValue = "10") int size) {
+                                 @RequestParam(defaultValue = "10") int size,
+                                 @RequestParam(required = false) String search) {
         String username = userService.getCurrentUser().orElseThrow(() -> new ResourceNotFoundException("User not found")).getUsername();
-        Page<CardDto> result = cardService.findByOwner(username, PageRequest.of(page, size))
+        Page<CardDto> result = cardService
+                .findByOwner(username, PageRequest.of(page, size), search)
                 .map(CardDto::fromEntity);
         return result;
     }

--- a/src/main/java/com/example/bankcards/repository/CardRepository.java
+++ b/src/main/java/com/example/bankcards/repository/CardRepository.java
@@ -14,6 +14,8 @@ import java.util.Optional;
 public interface CardRepository extends JpaRepository<Card, Long> {
     Page<Card> findByOwnerUsername(String username, Pageable pageable);
 
+    Page<Card> findByOwnerUsernameAndNumberContaining(String username, String number, Pageable pageable);
+
     Optional<Card> findByIdAndOwnerUsername(Long id, String username);
 
     Optional<Card> findByNumberAndOwnerUsername(String number, String username);

--- a/src/main/java/com/example/bankcards/service/CardService.java
+++ b/src/main/java/com/example/bankcards/service/CardService.java
@@ -37,8 +37,13 @@ public class CardService {
         return list;
     }
 
-    public Page<Card> findByOwner(String username, Pageable pageable) {
-        Page<Card> page = cardRepository.findByOwnerUsername(username, pageable);
+    public Page<Card> findByOwner(String username, Pageable pageable, String search) {
+        Page<Card> page;
+        if (search == null || search.isBlank()) {
+            page = cardRepository.findByOwnerUsername(username, pageable);
+        } else {
+            page = cardRepository.findByOwnerUsernameAndNumberContaining(username, search, pageable);
+        }
         return page;
     }
 

--- a/src/test/java/com/example/bankcards/service/CardServiceTest.java
+++ b/src/test/java/com/example/bankcards/service/CardServiceTest.java
@@ -11,6 +11,10 @@ import org.mockito.MockitoAnnotations;
 
 import java.util.Arrays;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -103,5 +107,30 @@ class CardServiceTest {
         assertEquals(BigDecimal.valueOf(15), to.getBalance());
         verify(cardRepository).save(from);
         verify(cardRepository).save(to);
+    }
+
+    @Test
+    void findByOwnerUsesSearchWhenProvided() {
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Card> page = new PageImpl<>(List.of(new Card()));
+        when(cardRepository.findByOwnerUsernameAndNumberContaining("u", "123", pageable))
+                .thenReturn(page);
+
+        Page<Card> result = cardService.findByOwner("u", pageable, "123");
+
+        verify(cardRepository).findByOwnerUsernameAndNumberContaining("u", "123", pageable);
+        assertEquals(page, result);
+    }
+
+    @Test
+    void findByOwnerWithoutSearchDelegatesSimpleQuery() {
+        Pageable pageable = PageRequest.of(0, 5);
+        Page<Card> page = new PageImpl<>(List.of(new Card()));
+        when(cardRepository.findByOwnerUsername("u", pageable)).thenReturn(page);
+
+        Page<Card> result = cardService.findByOwner("u", pageable, null);
+
+        verify(cardRepository).findByOwnerUsername("u", pageable);
+        assertEquals(page, result);
     }
 }


### PR DESCRIPTION
## Summary
- enable searching cards by partial number
- pass optional `search` parameter in service and controller
- document search query parameter in OpenAPI
- cover new service method with unit tests

## Testing
- `mvn -q test` *(fails: could not resolve maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68551c9d578083278ac4a2bb6fe76a33