### PR TITLE
Setup admin via Docker secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,8 @@ out/
 # Логи
 *.log
 
+# Секреты для docker-compose
+secrets/
+
 # Файлы MacOS
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+# Build stage
+FROM maven:3.9.6-eclipse-temurin-17 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn -q package -DskipTests
+
+# Runtime stage
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=build /app/target/*SNAPSHOT.jar app.jar
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/README_Bank_rest.md
+++ b/README_Bank_rest.md
@@ -5,15 +5,19 @@ REST API для работы с банковскими картами. Серв�
 ## Запуск приложения
 
 1. Установите Docker и Docker Compose.
-2. Поднимите базу данных командой:
+2. Создайте каталог `secrets` и положите туда файлы с секретами:
    ```bash
-   docker-compose up -d
+   mkdir -p secrets
+   echo "strong_db_pass" > secrets/db_password
+   echo "$(openssl rand -hex 32)" > secrets/jwt_secret
+   echo "admin" > secrets/admin_user
+   echo "admin_pass" > secrets/admin_password
    ```
-3. Соберите и запустите приложение:
+3. Поднимите сервисы командой:
    ```bash
-   mvn spring-boot:run
+   docker compose up --build -d
    ```
-   При старте автоматически выполняются Liquibase‑миграции.
+   При запуске приложение автоматически применит Liquibase‑миграции и создаст администратора из секретов.
 4. Откройте [http://localhost:8080/swagger-ui.html](http://localhost:8080/swagger-ui.html) для просмотра документации API.
 
 ## Получение JWT токена
@@ -31,7 +35,29 @@ REST API для работы с банковскими картами. Серв�
    В ответе будет JSON вида `{"token":"<JWT>"}`. Передавайте значение в заголовке:
 
    ```
-   Authorization: Bearer <JWT>
+  Authorization: Bearer <JWT>
+   ```
+
+## Вход под администратором и проверка API
+
+1. Получите токен администратора:
+   ```bash
+   ADMIN_TOKEN=$(curl -s \
+     "http://localhost:8080/api/auth/login?username=$(cat secrets/admin_user)&password=$(cat secrets/admin_password)" \
+     | jq -r .token)
+   ```
+2. В Swagger UI нажмите **Authorize** и введите `Bearer $ADMIN_TOKEN`.
+3. Или выполняйте запросы с помощью `curl`:
+   ```bash
+   curl -H "Authorization: Bearer $ADMIN_TOKEN" http://localhost:8080/api/cards
+   ```
+   Это вернёт список карт (изначально пустой).
+4. Создайте пользователя через API администратора:
+   ```bash
+   curl -X POST http://localhost:8080/api/users \
+        -H "Authorization: Bearer $ADMIN_TOKEN" \
+        -H 'Content-Type: application/json' \
+        -d '{"username":"test","password":"secret"}'
    ```
 
 ## Основные эндпоинты

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,45 @@ services:
     image: postgres:15
     environment:
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_PASSWORD_FILE: /run/secrets/db_password
       POSTGRES_DB: bankdb
     ports:
       - "5432:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
+    secrets:
+      - db_password
+
+  app:
+    build: .
+    depends_on:
+      - db
+    environment:
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_NAME: bankdb
+      DB_USER: postgres
+      DB_PASSWORD_FILE: /run/secrets/db_password
+      JWT_SECRET_FILE: /run/secrets/jwt_secret
+      ADMIN_USER_FILE: /run/secrets/admin_user
+      ADMIN_PASSWORD_FILE: /run/secrets/admin_password
+    ports:
+      - "8080:8080"
+    secrets:
+      - db_password
+      - jwt_secret
+      - admin_user
+      - admin_password
 
 volumes:
   postgres-data:
+
+secrets:
+  db_password:
+    file: ./secrets/db_password
+  jwt_secret:
+    file: ./secrets/jwt_secret
+  admin_user:
+    file: ./secrets/admin_user
+  admin_password:
+    file: ./secrets/admin_password

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+# Load secrets if *_FILE variables are provided
+if [ -n "$DB_PASSWORD_FILE" ]; then
+  export DB_PASSWORD="$(cat "$DB_PASSWORD_FILE")"
+fi
+if [ -n "$JWT_SECRET_FILE" ]; then
+  export JWT_SECRET="$(cat "$JWT_SECRET_FILE")"
+fi
+if [ -n "$ADMIN_USER_FILE" ]; then
+  export ADMIN_USER="$(cat "$ADMIN_USER_FILE")"
+fi
+if [ -n "$ADMIN_PASSWORD_FILE" ]; then
+  export ADMIN_PASSWORD="$(cat "$ADMIN_PASSWORD_FILE")"
+fi
+
+exec java -jar /app/app.jar

--- a/src/main/java/com/example/bankcards/config/AdminInitializer.java
+++ b/src/main/java/com/example/bankcards/config/AdminInitializer.java
@@ -1,0 +1,48 @@
+package com.example.bankcards.config;
+
+import com.example.bankcards.entity.Role;
+import com.example.bankcards.entity.User;
+import com.example.bankcards.service.UserService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+
+/**
+ * Создаёт администратора при старте приложения, используя учётные данные
+ * из переменных окружения.
+ */
+@Component
+public class AdminInitializer implements CommandLineRunner {
+    private final UserService userService;
+
+    @Value("${admin.username:}")
+    private String username;
+
+    @Value("${admin.password:}")
+    private String password;
+
+    public AdminInitializer(UserService userService) {
+        this.userService = userService;
+    }
+
+    @Override
+    public void run(String... args) {
+        if (username == null || username.isBlank()) {
+            return;
+        }
+        userService.findByUsername(username).ifPresentOrElse(user -> {
+            if (!user.getRoles().contains(Role.ROLE_ADMIN)) {
+                user.setRoles(Collections.singleton(Role.ROLE_ADMIN));
+                userService.update(user);
+            }
+        }, () -> {
+            User admin = new User();
+            admin.setUsername(username);
+            admin.setPassword(password);
+            admin.setRoles(Collections.singleton(Role.ROLE_ADMIN));
+            userService.save(admin);
+        });
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,10 @@ jwt:
   secret: ${JWT_SECRET}
   expiration: 3600000
 
+admin:
+  username: ${ADMIN_USER}
+  password: ${ADMIN_PASSWORD}
+
 springdoc:
   api-docs:
     path: /v3/api-docs


### PR DESCRIPTION
## Summary
- add Docker build and runtime config
- load secrets through entrypoint
- create admin user on startup
- document how to use secrets and admin features

## Testing
- `mvn test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6856806566c08327a42e02b9d1c73055