### PR TITLE
Fix schema validation failure

### DIFF
--- a/src/main/resources/db/migration/db.changelog-master.yaml
+++ b/src/main/resources/db/migration/db.changelog-master.yaml
@@ -87,3 +87,15 @@ databaseChangeLog:
         - sql: CREATE EXTENSION IF NOT EXISTS pgcrypto;
         - sql: |
             UPDATE cards SET number = encode(pgp_sym_encrypt(number, 'MySecretKey12345'), 'base64');
+
+  - changeSet:
+      id: 3
+      author: add_version
+      changes:
+        - addColumn:
+            tableName: cards
+            columns:
+              - column:
+                  name: version
+                  type: BIGINT
+


### PR DESCRIPTION
## Summary
- add Liquibase migration to create the `version` column in `cards`

## Testing
- `mvn -q test` *(fails: Could not resolve Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6856c80effbc832785f6f82d7eddb1a3