### PR TITLE
Review feedback

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -118,6 +118,18 @@ paths:
       responses:
         "200":
           description: Карта заблокирована
+  /api/cards/{id}/activate:
+    post:
+      summary: Активация карты
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: Карта активирована
   /api/cards/transfer:
     post:
       summary: Перевод между картами пользователя


### PR DESCRIPTION
## Summary
- restore comprehensive unit tests for CardService
- document card activation endpoint in the OpenAPI spec

## Testing
- `mvn -q test` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6856cdaa33048327bc034af3e3d24f54